### PR TITLE
Fix build on Android: SIGEMT and SIGINFO are not defined by bionic

### DIFF
--- a/znet/include/znet/signal_handler.h
+++ b/znet/include/znet/signal_handler.h
@@ -25,7 +25,7 @@ enum Signal {
   kSignalTrap = SIGTRAP,
 #endif
   kSignalAbort = SIGABRT,
-#if (defined(_POSIX_C_SOURCE) && !defined(_DARWIN_C_SOURCE)) || defined(EMSCRIPTEN)
+#if (defined(_POSIX_C_SOURCE) && !defined(_DARWIN_C_SOURCE)) || defined(EMSCRIPTEN) || defined(__ANDROID__)
   kSignalPoll = SIGPOLL,
 #elif !defined(TARGET_WIN) /* (!_POSIX_C_SOURCE || _DARWIN_C_SOURCE) */
   kSignalEMT = SIGEMT,
@@ -55,7 +55,7 @@ enum Signal {
   kSignalProfilingAlarm = SIGPROF,
 #if (!defined(_POSIX_C_SOURCE) || defined(_DARWIN_C_SOURCE))
   kSignalWindowSize = SIGWINCH,
-#if !defined(EMSCRIPTEN)
+#if !defined(EMSCRIPTEN) && !defined(__ANDROID__)
   kSignalInfo = SIGINFO,
 #endif
 #endif


### PR DESCRIPTION
- signal_handler.h's Signal enum used SIGEMT as the fallback signal for any non-Windows, non-strict-POSIX/Emscripten platform, and SIGINFO unconditionally on any platform other than Emscripten. Both assume a BSD-style libc (macOS, glibc on Linux) that defines them, which Android's bionic libc does not - confirmed against the NDK's asm-generic/signal.h, which defines SIGPOLL/SIGIO/SIGWINCH but not SIGEMT or SIGINFO.

- Routes ANDROID through the same SIGPOLL branch already used for strict POSIX/Emscripten, and skips SIGINFO on ANDROID the same way it's already skipped on EMSCRIPTEN.